### PR TITLE
Handles resources without a source file.

### DIFF
--- a/lib/middleman-inliner.rb
+++ b/lib/middleman-inliner.rb
@@ -13,7 +13,7 @@ class Inliner < Middleman::Extension
     def inline_css(*names)
       names.map { |name|
         name += ".css" unless name.include?(".css")
-        css_path = sitemap.resources.select { |p| p.source_file.include?(name) }.first
+        css_path = sitemap.resources.select { |p| p.source_file.include?(name) unless p.source_file.nil? }.first
         "<style type='text/css'>#{css_path.render}</style>"
       }.reduce(:+)
     end


### PR DESCRIPTION
Some extensions (such as middleman-automatic-clowncar) create sitemap resources that do not have a corresponding source_file. This was causing the "p.source_file.include?(name)" expression to raise an error (as the nil object does not have an include? method).

This small change will only evaluate the expression when the source_file is not nil.
